### PR TITLE
Set build.rb to be executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN ln -s $(pwd)/build.rb /usr/local/bin/nwn-build
 # Modify build.rb to ignore host environment configs
 RUN echo '#!/usr/bin/env ruby\nINSTALL_DIR = ENV["NWN_INSTALLDIR"]' \
     | cat - build.rb > tmp.rb \
-    && mv tmp.rb build.rb
+    && mv tmp.rb build.rb && chmod 755 build.rb
 # Configure devbase user
 RUN adduser devbase --disabled-password --gecos "" --uid 1000
 RUN echo "devbase ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers


### PR DESCRIPTION
On "docker run" the docker container was complaining that
the nwn-build (symlink to build.rb) executable file was
not found in $PATH