### PR TITLE
Updated encoding variable to windows-1252

### DIFF
--- a/config.rb.in
+++ b/config.rb.in
@@ -30,4 +30,4 @@ SCRIPTS_DIR ||= file_exists(PROJECT_ROOT.join("scripts")) || file_exists(EXECUTI
 NSS_COMPILER ||= ENV["NSS_COMPILER"] || "nwnsc"
 NSS_BATCHOUTDIR ||= GFF_CACHE_DIR
 COMPILER_ARGS ||= ["-qo", "-n", "#{INSTALL_DIR}", "-y", "-b", "#{NSS_BATCHOUTDIR}"]
-ENCODING ||= "utf-8"
+ENCODING ||= "windows-1252"


### PR DESCRIPTION
The **"Encoding"** variable sets the nwn-gff input files encoding. By default NWN GFF files are always encoded using windows-1252 (According to NWNEE Discord at least)

I've updated this because I was trying to extract a spanish module data and every time a gff had a spanish character (I.E: á, é, í, ó, ú or ñ. I think there were others but didn't check throughfully) that file extraction would fail due to incorrect encoding.

Once I changed the encoding variable back to windows-1252 everything started working once again. It looks like nwn-gff outputs are [already encoded to UTF-8 according to documentation](https://github.com/niv/nwn-lib/blob/master/SETTINGS.rdoc#nwn_lib_in_encoding).